### PR TITLE
fix sudo : builtin command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,8 +33,8 @@ if (( "$UID" ));
     a_privilege+=( "sudo" )
     echo "This script requires privileges"
     echo "to install packages and write to top-level files / directories."
-    echo "Invoking \`sudo' to acquire the permission:"
-    "${a_privilege[@]}" :
+    echo "Invoking \`${a_privilege[*]}' to acquire the permission:"
+    "${a_privilege[@]}" bash -c ":"
 fi
 
 # install docker


### PR DESCRIPTION
This PR fixes the error introduced in #1 in`install.sh`  line 37

https://github.com/darkthread/nginx-certbot-docker-nstaller/blob/f95e0685997e143d6b59c093b40ce37de6b74a6e/install.sh#L37

```sh
sudo :
```

does not work on Debian or Ubuntu since `:` (no-op) here is only a bash shell built-in but not an executable. `sudo` will try to find the executable inside the `PATH` environment variable with the name given by its first argument, and it would fail if it doesn't exist. Similar error would occur to utilities such as `find -exec`.

https://superuser.com/questions/241129/why-wont-sudo-cd-work/241131#241131

This fix works by executing `:` as a Bash command under a Bash sub-shell (with `bash -c "your command"`). Now `sudo` will be able to find the executable (which is now `bash`).

I'm terribly sorry for not checking the unprivileged execution of the script prior to submitting #1.  This PR is tested in a Debian virtual machine build with VirutalBox for both privileged and unprivileged execution.

